### PR TITLE
remove oob from docs, as it is not supported in the API code

### DIFF
--- a/docs/guide/sdk_setup.rst
+++ b/docs/guide/sdk_setup.rst
@@ -52,8 +52,7 @@ As with token authentication, a few fields are passed into the object on creatio
 			'host' => 'your-company.checkfront.com',
 			'auth_type' => 'oauth2',
 			'consumer_key' => '1d2d5cad60174b5972243693d082e4b4e54979bf',
-			'consumer_secret' => '8e3751291c3d0fe090a7d5b18d964407baff96c1028e1e1afb1014d1db85b25a',
-			'redirect_uri' => 'oob'
+			'consumer_secret' => '8e3751291c3d0fe090a7d5b18d964407baff96c1028e1e1afb1014d1db85b25a'
 		)
 	);
 


### PR DESCRIPTION
Hey guys, I am trying my best to leave the Checkfront API code alone as I continue to develop. This issue was a little pain as this documentation says I should be able to use ```'redirect_uri' => 'oob'``` and pass the redirect_uri within the oAuth2 authentication process. 

As the docs states when using ```fetch_token($code)``` correctly it errors and will return the following error upon debugging the CURL request.

```Array ( [error] => redirect_uri_mismatch [error_description] => The redirect URI is missing or invalid )```

I looked over the doc and only see ```'redirect_uri' => 'oob'``` referenced once. Maybe is can be removed until the API code receives an update?