### PR TITLE
Document the item_id filter for booking/index

### DIFF
--- a/docs/ref/booking/index.rst
+++ b/docs/ref/booking/index.rst
@@ -13,6 +13,7 @@ booking/index
 	:query string/timestamp end_date: The date the booking ends on (i.e. check-out).
 	:query string/timestamp last_modified: The date the booking was last changed. Useful for getting bookings added or changed since your last call.
 	:query string partner_id: The partner account ID that a booking is attributed to.
+	:query integer item_id: The ID of an item attached to the booking.
 	:query integer limit: The limit of bookings to return per page (default: 100).
 	:query integer page: The page of results to return.
 	

--- a/docs/requirements.pip
+++ b/docs/requirements.pip
@@ -1,1 +1,2 @@
 sphinxcontrib-httpdomain
+sphinx_rtd_theme


### PR DESCRIPTION
Also specifically defines the sphinx_rtd_theme under requirements due to: 
`Theme error:
sphinx_rtd_theme is no longer a hard dependency since version 1.4.0. Please install it manually.(pip install sphinx_rtd_theme)`