### PR TITLE
Document sessionless booking creation

### DIFF
--- a/docs/ref/booking/create.rst
+++ b/docs/ref/booking/create.rst
@@ -6,5 +6,6 @@ A call to booking/create must pass in at least one :ref:`slip` - either directly
 
 	Attempt to create a booking from an existing session, with customer form input sent in the request in the "form" parameter.
 
-	:form form: An array of fields containing customer details matching the required and optional booking fields (e.g. ``form[customer_name]="John Smith"``)
-	:form session_id: The session ID containing the booking items to be committed.  *Can also be sent as a cookie.*
+	:form array form: An array of fields containing customer details matching the required and optional booking fields (e.g. ``form[customer_name]="John Smith"``)
+	:form string session_id: The session ID containing the booking items to be committed.  *Can also be sent as a cookie.*
+	:form string/array slip: A :ref:`slip` or array of :ref:`slip`\s that can be passed directly to booking/create, bypassing the need to specify a session_id

--- a/docs/ref/booking/create.rst
+++ b/docs/ref/booking/create.rst
@@ -1,6 +1,6 @@
 booking/create
 --------------
-A call to booking/create must pass in a **session_id** for a :doc:`session` containing at least one :ref:`slip` in addition to customer input entered to fields from :doc:`form`
+A call to booking/create must pass in at least one :ref:`slip` - either directly as an array of slips, or by using a **session_id** from a previously created :doc:`session` containing at least one :ref:`slip`. Additionally, the call must pass in any customer input entered to fields from :doc:`form`, for all required fields and any optional fields.
 
 .. http:post:: /api/3.0/booking/create
 


### PR DESCRIPTION
Document ability to pass booking slips directly to booking/create, bypassing the need for a call to booking/session