### PR TITLE
Public api information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _build*
 build/*
 .vscode
+*.code-workspace

--- a/docs/overview/getting_started.rst
+++ b/docs/overview/getting_started.rst
@@ -46,21 +46,21 @@ When the rate limit is exceeded Checkfront will send an HTTP 503 status code.  T
 
 The Public API
 --------------
-Checkfront provides a public API feature that allows un-authenticated users to pull information about items and availability. This data is a reduced version of what you can obtain using the authenticated API, and only provides already public information that could otherwise be accessed by going to the `Customer Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
+Checkfront provides a public API feature that allows unauthenticated users to pull information about items and availability. This data is an alternate version of what you can obtain using the authenticated API, and only provides already public information that could otherwise be accessed from the `Customer Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
 
-The public API can be enabled in your Checkfront account under *Manage > Developer > API*. By default this API option is disabled, but can be enabled manually by any Admin account. This option will be enabled automatically if you enable **Site Builder** and can not be turned back off until **Site Builder** is disabled.
+The public API can be enabled in your Checkfront account under *Manage > Developer > API*. By default this API option is disabled, but can be enabled manually by any Admin account. This option will be enabled automatically if `Site Builder <https://support.checkfront.com/hc/en-us/categories/115000337433-Site-Builder>`_ is activated on the account and can not be turned back off until `Site Builder <https://support.checkfront.com/hc/en-us/categories/115000337433-Site-Builder>`_ is disabled.
 
 The public API can be tested in the Checkfront console (*Manage > Developer > Console*) by toggling the *Access* Username in the top, left-hand corner. If you're testing the API using an external tool, you can test the public API by setting the *X-On-Behalf* header to *Off*.
 
 The endpoints that can be accessed using the public API are as follows:
 
-- :doc:`/ref/booking/session`
-- :doc:`/ref/booking/create`
-- :doc:`/ref/booking/form`
 - :doc:`/ref/category`
 - :doc:`/ref/company`
 - :doc:`/ref/help`
 - :doc:`/ref/item/`
+- :doc:`/ref/booking/session`
+- :doc:`/ref/booking/form`
+- :doc:`/ref/booking/create`
 - :doc:`/ref/ping`
 
 Terms of Service

--- a/docs/overview/getting_started.rst
+++ b/docs/overview/getting_started.rst
@@ -44,6 +44,25 @@ API throttle limit: We reserve the right to tune the limitations, but they are a
 When the rate limit is exceeded Checkfront will send an HTTP 503 status code.  The number of seconds until the throttle is lifted is sent via the "Retry-After" HTTP header, as specified in RFC 2616.
 
 
+The Public API
+--------------
+Checkfront provides a public API feature that allows un-authenticated users to pull information about items and availability. This data is a reduced version of what you can obtain using the authenticated API, and only provides already public information that could otherwise be accessed by going to the `Customer Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
+
+The public API can be enabled in your Checkfront account under *Manage > Developer > API*. By default this API option is disabled, but can be enabled manually by any Admin account. This option will be enabled automatically if you enable **Site Builder** and can not be turned back off until **Site Builder** is disabled.
+
+The public API can be tested in the Checkfront console (*Manage > Developer > Console*) by toggling the *Access* Username in the top, left-hand corner. If you're testing the API using an external tool, you can test the public API by setting the *X-On-Behalf* header to *Off*.
+
+The endpoints that can be accessed using the public API are as follows:
+
+- :doc:`/ref/booking/session`
+- :doc:`/ref/booking/create`
+- :doc:`/ref/booking/form`
+- :doc:`/ref/category`
+- :doc:`/ref/company`
+- :doc:`/ref/help`
+- :doc:`/ref/item/`
+- :doc:`/ref/ping`
+
 Terms of Service
 ----------------
 Use of this API is strictly bound by the terms as specified in `Checkfront API Terms of Service <https://www.checkfront.com/terms/#_api?cfcp=api>`_.

--- a/docs/ref/booking/create.rst
+++ b/docs/ref/booking/create.rst
@@ -4,7 +4,7 @@ A call to booking/create must pass in at least one :ref:`slip` - either directly
 
 Public API
 ----------
-If the Public API is enabled, non-authenticated users can make requests to the */booking/create* end point. This is the same functionality as a customer making a booking through the UI on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
+If the Public API is enabled, unauthenticated users can make requests to the */booking/create* endpoint. This is the same functionality as a customer making a booking through the UI on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
 
 .. http:post:: /api/3.0/booking/create
 

--- a/docs/ref/booking/create.rst
+++ b/docs/ref/booking/create.rst
@@ -1,6 +1,10 @@
 booking/create
---------------
+==============
 A call to booking/create must pass in at least one :ref:`slip` - either directly as an array of slips, or by using a **session_id** from a previously created :doc:`session` containing at least one :ref:`slip`. Additionally, the call must pass in any customer input entered to fields from :doc:`form`, for all required fields and any optional fields.
+
+Public API
+----------
+If the Public API is enabled, non-authenticated users can make requests to the */booking/create* end point. This is the same functionality as a customer making a booking through the UI on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
 
 .. http:post:: /api/3.0/booking/create
 

--- a/docs/ref/booking/form.rst
+++ b/docs/ref/booking/form.rst
@@ -1,8 +1,12 @@
 booking/form
-------------
+============
 This call can easily be cached if your configuration does not often change, but depending on your setup, a number of the fields returned in this request may be required to complete a booking.
 
 You will receive an error indicating missing information if you attempt to call :doc:`create` without the required fields, either those required by staff if you're acting on behalf of a staff member, or by a customer otherwise.
+
+Public API
+----------
+If the Public API is enabled, non-authenticated users can make requests to the */booking/forms* end point. This is the same functionality as a customer viewing the form when making a booking on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_. Only form fields that are set to show on the Customer Booking Form will be returned. Check out our Knowledge Base for more information on `Booking Form Field Options <https://support.checkfront.com/hc/en-us/articles/360007374474-Booking-Form-Field-Editor-Options-Tab>`_.
 
 .. http:get:: /api/3.0/booking/form
 

--- a/docs/ref/booking/form.rst
+++ b/docs/ref/booking/form.rst
@@ -6,7 +6,7 @@ You will receive an error indicating missing information if you attempt to call 
 
 Public API
 ----------
-If the Public API is enabled, non-authenticated users can make requests to the */booking/forms* end point. This is the same functionality as a customer viewing the form when making a booking on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_. Only form fields that are set to show on the Customer Booking Form will be returned. Check out our Knowledge Base for more information on `Booking Form Field Options <https://support.checkfront.com/hc/en-us/articles/360007374474-Booking-Form-Field-Editor-Options-Tab>`_.
+If the Public API is enabled, unauthenticated users can make requests to the */booking/forms* end point. This is the same functionality as a customer viewing the form when making a booking on the `Customer Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_. Only form fields that are set to show on the Customer Booking Form will be returned. See out our Knowledge Base for more information on `Booking Form Field Options <https://support.checkfront.com/hc/en-us/articles/360007374474-Booking-Form-Field-Editor-Options-Tab>`_.
 
 .. http:get:: /api/3.0/booking/form
 

--- a/docs/ref/booking/form.rst
+++ b/docs/ref/booking/form.rst
@@ -6,7 +6,7 @@ You will receive an error indicating missing information if you attempt to call 
 
 Public API
 ----------
-If the Public API is enabled, unauthenticated users can make requests to the */booking/forms* end point. This is the same functionality as a customer viewing the form when making a booking on the `Customer Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_. Only form fields that are set to show on the Customer Booking Form will be returned. See out our Knowledge Base for more information on `Booking Form Field Options <https://support.checkfront.com/hc/en-us/articles/360007374474-Booking-Form-Field-Editor-Options-Tab>`_.
+If the Public API is enabled, unauthenticated users can make requests to the */booking/forms* endpoint. This is the same functionality as a customer viewing the form when making a booking on the `Customer Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_. Only form fields that are set to show on the Customer Booking Form will be returned. See out our Knowledge Base for more information on `Booking Form Field Options <https://support.checkfront.com/hc/en-us/articles/360007374474-Booking-Form-Field-Editor-Options-Tab>`_.
 
 .. http:get:: /api/3.0/booking/form
 

--- a/docs/ref/booking/session.rst
+++ b/docs/ref/booking/session.rst
@@ -9,7 +9,7 @@ To start a new session, you simply pass in the booking :ref:`slip`\s returned wh
 
 Public API
 ----------
-If the Public API is enabled, unauthenticated users can make requests to the */booking/sessions* end point. This is the same functionality as a customer adding an item to a booking through the UI on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
+If the Public API is enabled, unauthenticated users can make requests to the */booking/sessions* endpoint. This is the same functionality as a customer adding an item to a booking through the UI on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
 
 .. http:post:: /api/3.0/booking/session
 

--- a/docs/ref/booking/session.rst
+++ b/docs/ref/booking/session.rst
@@ -9,7 +9,7 @@ To start a new session, you simply pass in the booking :ref:`slip`\s returned wh
 
 Public API
 ----------
-If the Public API is enabled, non-authenticated users can make requests to the */booking/sessions* end point. This is the same functionality as a customer adding an item to a booking through the UI on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
+If the Public API is enabled, unauthenticated users can make requests to the */booking/sessions* end point. This is the same functionality as a customer adding an item to a booking through the UI on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
 
 .. http:post:: /api/3.0/booking/session
 

--- a/docs/ref/booking/session.rst
+++ b/docs/ref/booking/session.rst
@@ -7,6 +7,10 @@ Each session call will return the **session_id** of the active session, and any 
 
 To start a new session, you simply pass in the booking :ref:`slip`\s returned when from earlier "**rated**" inventory :doc:`../item` queries.
 
+Public API
+----------
+If the Public API is enabled, non-authenticated users can make requests to the */booking/sessions* end point. This is the same functionality as a customer adding an item to a booking through the UI on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
+
 .. http:post:: /api/3.0/booking/session
 
 	Create or return information about and stored in the current server session.

--- a/docs/ref/category.rst
+++ b/docs/ref/category.rst
@@ -10,7 +10,7 @@ category
 
 Public API
 ----------
-If the Public API is enabled, unauthenticated users can make requests to the */category* end point. This is the same functionality as a customer viewing the categories on the `Customer Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_. Only categories that are publicly visible and have customer-visible items will be returned. Check out our Knowledge Base for more information on how `Categories display on the Booking Page <https://support.checkfront.com/hc/en-us/articles/360007510473-Booking-Page-Category-Display>`_.
+If the Public API is enabled, unauthenticated users can make requests to the */category* endpoint. This is the same functionality as a customer viewing the categories on the `Customer Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_. Only categories that are publicly visible and have customer-visible items will be returned. Check out our Knowledge Base for more information on how `Categories display on the Booking Page <https://support.checkfront.com/hc/en-us/articles/360007510473-Booking-Page-Category-Display>`_.
 
 .. literalinclude:: ../examples/response/category.json
 	:language: json

--- a/docs/ref/category.rst
+++ b/docs/ref/category.rst
@@ -8,6 +8,10 @@ category
 	:>jsonarr string name: The display name of the category.
 	:>jsonarr integer pos: The order in which the category will display.
 
+Public API
+----------
+If the Public API is enabled, non-authenticated users can make requests to the */category* end point. This is the same functionality as a customer viewing the categories on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_. Only categories that are publicly visible and have customer-visible items will be returned. Check out our Knowledge Base for more information on how `Categories display on the Booking Page <https://support.checkfront.com/hc/en-us/articles/360007510473-Booking-Page-Category-Display>`_.
+
 .. literalinclude:: ../examples/response/category.json
 	:language: json
 	:linenos:

--- a/docs/ref/category.rst
+++ b/docs/ref/category.rst
@@ -10,7 +10,7 @@ category
 
 Public API
 ----------
-If the Public API is enabled, non-authenticated users can make requests to the */category* end point. This is the same functionality as a customer viewing the categories on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_. Only categories that are publicly visible and have customer-visible items will be returned. Check out our Knowledge Base for more information on how `Categories display on the Booking Page <https://support.checkfront.com/hc/en-us/articles/360007510473-Booking-Page-Category-Display>`_.
+If the Public API is enabled, unauthenticated users can make requests to the */category* end point. This is the same functionality as a customer viewing the categories on the `Customer Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_. Only categories that are publicly visible and have customer-visible items will be returned. Check out our Knowledge Base for more information on how `Categories display on the Booking Page <https://support.checkfront.com/hc/en-us/articles/360007510473-Booking-Page-Category-Display>`_.
 
 .. literalinclude:: ../examples/response/category.json
 	:language: json

--- a/docs/ref/company.rst
+++ b/docs/ref/company.rst
@@ -23,7 +23,7 @@ company
 
 Public API
 ----------
-If the Public API is enabled, unauthenticated users can make requests to the */company* end point. Both the public and authenticated responses are identical.
+If the Public API is enabled, unauthenticated users can make requests to the */company* endpoint. Both the public and authenticated responses are identical.
 
 .. literalinclude:: ../examples/response/company.json
 	:language: json

--- a/docs/ref/company.rst
+++ b/docs/ref/company.rst
@@ -23,7 +23,7 @@ company
 
 Public API
 ----------
-If the Public API is enabled, non-authenticated users can make requests to the */company* end point. Both the public and authenticated responses are identical.
+If the Public API is enabled, unauthenticated users can make requests to the */company* end point. Both the public and authenticated responses are identical.
 
 .. literalinclude:: ../examples/response/company.json
 	:language: json

--- a/docs/ref/company.rst
+++ b/docs/ref/company.rst
@@ -21,6 +21,10 @@ company
 	:>json string date_format: The date format set for the company.
 	:>json string time_format: The time format set for the company.
 
+Public API
+----------
+If the Public API is enabled, non-authenticated users can make requests to the */company* end point. Both the public and authenticated responses are identical.
+
 .. literalinclude:: ../examples/response/company.json
 	:language: json
 	:linenos:

--- a/docs/ref/help.rst
+++ b/docs/ref/help.rst
@@ -5,6 +5,10 @@ help
 
 	Retrieve a list of API endpoints.
 
+Public API
+----------
+If the Public API is enabled, non-authenticated users can make requests to the */help* end point. Both the public and authenticated responses are identical.
+
 .. literalinclude:: ../examples/response/help.json
 	:language: json
 	:linenos:

--- a/docs/ref/help.rst
+++ b/docs/ref/help.rst
@@ -7,7 +7,7 @@ help
 
 Public API
 ----------
-If the Public API is enabled, non-authenticated users can make requests to the */help* end point. Both the public and authenticated responses are identical.
+If the Public API is enabled, unauthenticated users can make requests to the */help* end point. Both the public and authenticated responses are identical.
 
 .. literalinclude:: ../examples/response/help.json
 	:language: json

--- a/docs/ref/help.rst
+++ b/docs/ref/help.rst
@@ -7,7 +7,7 @@ help
 
 Public API
 ----------
-If the Public API is enabled, unauthenticated users can make requests to the */help* end point. Both the public and authenticated responses are identical.
+If the Public API is enabled, unauthenticated users can make requests to the */help* endpoint. Both the public and authenticated responses are identical.
 
 .. literalinclude:: ../examples/response/help.json
 	:language: json

--- a/docs/ref/item.rst
+++ b/docs/ref/item.rst
@@ -28,7 +28,11 @@ Booking parameters have many options, and can be configured to control inventory
 
 Public API
 ----------
-If the Public API is enabled, non-authenticated users can make requests to the */item*, */item/{id}*, */item/cal*, and */item/{id}/cal* end points. The responses between the internal and public API versions are identical for the *item/* and *item/{id}* endpoints. For the *item/cal* and *item/{id}/cal* endpoints the response will return 1 if the item is available instead of the available inventory. This is the same functionality as a customer viewing the item or availability calendar on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
+If the Public API is enabled, unauthenticated users can make requests to the */item*, */item/{id}*, */item/cal*, and */item/{id}/cal* end points. This is the same functionality as a customer viewing the item or availability calendar on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
+
+For the *item/* and *item/{id}* endpoints, the responses between the internal and public API versions have an identical structure. The public response for these endpoints will only return customer rules and item visibility; staff rules and visibility will not be returned. 
+
+For the *item/cal* and *item/{id}/cal* endpoints the public response will return 1 if the item is available instead of the available inventory.
 
 Request
 -------

--- a/docs/ref/item.rst
+++ b/docs/ref/item.rst
@@ -26,6 +26,10 @@ Say for instance you have 2 parameters configured: Adults (id: adults), and Chil
 
 Booking parameters have many options, and can be configured to control inventory in very specific ways.  See the Checkfront support centre or ask us for more information.
 
+Public API
+----------
+If the Public API is enabled, non-authenticated users can make requests to the */item*, */item/{id}*, */item/cal*, and */item/{id}/cal* end points. The responses between the internal and public API versions are identical for the *item/* and *item/{id}* endpoints. For the *item/cal* and *item/{id}/cal* endpoints the response will return 1 if the item is available instead of the available inventory. This is the same functionality as a customer viewing the item or availability calendar on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
+
 Request
 -------
 

--- a/docs/ref/item.rst
+++ b/docs/ref/item.rst
@@ -28,7 +28,7 @@ Booking parameters have many options, and can be configured to control inventory
 
 Public API
 ----------
-If the Public API is enabled, unauthenticated users can make requests to the */item*, */item/{id}*, */item/cal*, and */item/{id}/cal* end points. This is the same functionality as a customer viewing the item or availability calendar on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
+If the Public API is enabled, unauthenticated users can make requests to the */item*, */item/{id}*, */item/cal*, and */item/{id}/cal* endpoints. This is the same functionality as a customer viewing the item or availability calendar on the `Hosted Booking Page <https://support.checkfront.com/hc/en-us/articles/115004917593-Hosted-Booking-Page>`_.
 
 For the *item/* and *item/{id}* endpoints, the responses between the internal and public API versions have an identical structure. The public response for these endpoints will only return customer rules and item visibility; staff rules and visibility will not be returned. 
 

--- a/docs/ref/ping.rst
+++ b/docs/ref/ping.rst
@@ -7,7 +7,7 @@ ping
 
 Public API
 ----------
-If the Public API is enabled, unauthenticated users can make requests to the */ping* end point. Both the public and authenticated responses are identical.
+If the Public API is enabled, unauthenticated users can make requests to the */ping* endpoint. Both the public and authenticated responses are identical.
 
 .. literalinclude:: ../examples/response/ping.json
 	:language: json

--- a/docs/ref/ping.rst
+++ b/docs/ref/ping.rst
@@ -5,6 +5,10 @@ ping
 
 	Show API connection details and latency.
 
+Public API
+----------
+If the Public API is enabled, non-authenticated users can make requests to the */ping* end point. Both the public and authenticated responses are identical.
+
 .. literalinclude:: ../examples/response/ping.json
 	:language: json
 	:linenos:

--- a/docs/ref/ping.rst
+++ b/docs/ref/ping.rst
@@ -7,7 +7,7 @@ ping
 
 Public API
 ----------
-If the Public API is enabled, non-authenticated users can make requests to the */ping* end point. Both the public and authenticated responses are identical.
+If the Public API is enabled, unauthenticated users can make requests to the */ping* end point. Both the public and authenticated responses are identical.
 
 .. literalinclude:: ../examples/response/ping.json
 	:language: json


### PR DESCRIPTION
Add information regarding the public API to relevant endpoints.

- Gave each relevant endpoint a new section to indicate it was accessible through the public API
- Included information on any differences between the responses if available
- Linked to Knowledge Base articles about standard Checkfront features when relevant